### PR TITLE
Feature(Docker) : add production-ready Dockerfile for frontend client #122

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx:alpine
+
+WORKDIR /usr/share/nginx/html
+
+COPY . /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]
+


### PR DESCRIPTION
Working on Cli
![Screenshot 2024-10-05 113948](https://github.com/user-attachments/assets/b028f44c-b74e-4e61-8c7b-53231067a4fd)

Project run on localhost 8080 , on gcloud

![Screenshot 2024-10-05 114021](https://github.com/user-attachments/assets/94be67ae-c3ce-4a4b-914f-9a210a6e31f7)

to run that Dockerfile

build command

`docker build -t my-html-app .`

run command

`docker run -d -p 8080:80 my-html-app`
