### PR TITLE
Fixed the hovering color miscorrection error on Contact us box

### DIFF
--- a/faq.css
+++ b/faq.css
@@ -34,6 +34,13 @@
   h2:hover{
     color: #1fb899
   }
+  .contact-info h2:hover{
+    color: black
+  }
+  .contact-info h4:hover{
+    color: black
+  }
+  
   
   details {
     cursor: pointer;


### PR DESCRIPTION
## What does this PR do?

The text in Contact box was not going with the UI. While hovering It was just getting disappeared submerging with the background. So I fixed that error by some slight changes

Fixes #152 

[GSSOC-EXT , HACKTOBER]

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Chore (refactoring code, technical debt, workflow improvements)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Screenshots 

![Screenshot (41)](https://github.com/user-attachments/assets/a5ae2299-57f5-48a1-a12e-f4d9cab39ef6)
![Screenshot (42)](https://github.com/user-attachments/assets/6c0f3759-4f2f-4328-b6ae-ca68f4996811)

## Mandatory Tasks

- [x ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.