### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,29 @@ To submit your contributions, follow these steps:
 8. **Submit a Pull Request**: Go to your forked repository on GitHub and submit a pull request. Be sure to provide a detailed description of your changes and why they are necessary.
 
 🎉 Voila! You have made a PR to the Ticket-Booking project. Sit back patiently and relax while the project maintainers review your PR.
----
+
+![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)
+
+
+
+
+## This project is now OFFICIALLY accepted for 
+
+<div align="center">
+  <img src="https://github.com/amiya-cyber/banner/blob/main/329829127-e79eb6de-81b1-4ffb-b6ed-f018bb977e88.png" alt="GSSoC 2024 Extd" width="60%">
+</div>
+
+<div align="center">
+  <img src="https://github.com/amiya-cyber/banner/blob/main/hacktober.png" alt="Hacktober fest 2024" width="60%">
+</div>
+
+
+![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)
+
+
+
+
+
 
 ## ❤️ Our Valuable Contributors
 


### PR DESCRIPTION
ADD HACKTOBERFEST AND GSSOC BANNER ON THE README

## What does this PR do?

 By Adding these banners at the appropriate location to showcase the project's involvement in these events.
The Hacktoberfest and GSSoC banners appear on the README file, ideally at the top, to indicate that the project is part of these events.

Fixes #559 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change

documentation update
ADDED HACKTOBERFEST AND GSSOC BANNER ON THE README


-
## Screenshots 

![2024-10-23 (13)](https://github.com/user-attachments/assets/675a9f75-22cf-492f-b19d-f413935e321d)


## Mandatory Tasks

- [ x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.