### PR TITLE
#567-mouse-hide-fix

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,6 +1,6 @@
 /* cursor */
 body {
-  cursor: none;
+  cursor: default;
 }
 
 .circle {


### PR DESCRIPTION
## What does this PR do?

When on Sell and About page, the mouse cursor can't be seen over the window.
Probably because the cursor was set to none.


## Fixes 
### Before
<img width="185" alt="Screenshot 2024-10-24 at 2 06 49 PM" src="https://github.com/user-attachments/assets/f79dfea8-8dd9-4876-b617-e1880947c699">

### After
<img width="245" alt="Screenshot 2024-10-24 at 2 06 44 PM" src="https://github.com/user-attachments/assets/d7199d53-b7c8-46bb-a32b-bdc44d0171aa">

## Results
### Before
https://github.com/user-attachments/assets/e53d5a27-8ce0-4aa8-ad40-98c5adeaa173

### After
https://github.com/user-attachments/assets/1dc61476-d684-46db-8f3f-83907fb87ed0




