### PR TITLE
contributors dark mode update

### DIFF
--- a/contributor.css
+++ b/contributor.css
@@ -500,3 +500,20 @@ body {
     text-align: center;
   }
 }
+
+
+.contributor-stats-grid, 
+.contributor-contributors-grid {
+    color: #000000; /* Default text color for grids */
+}
+
+
+body.dark-mode .contributor-stats-grid, 
+body.dark-mode .contributor-contributors-grid {
+    color: #000000; /* Text color for content in dark mode */
+}
+
+/* Optional: Background color for dark mode */
+body.dark-mode {
+    background-color: #121212; /* Example dark background */
+}


### PR DESCRIPTION
## What does this PR do?

In contributors page , in Dark mode, text was not visible earlier. now its visible

Fixes #564 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Chore (refactoring code, technical debt, workflow improvements)
- New feature (non-breaking change which adds functionality)

## Screenshots 
Before:

<img width="1440" alt="Screenshot 2024-10-25 at 8 03 01 PM" src="https://github.com/user-attachments/assets/afc8c020-b1af-4e1d-9747-f165034b0f99">

After:
<img width="1440" alt="Screenshot 2024-10-25 at 8 02 55 PM" src="https://github.com/user-attachments/assets/0a905107-cc1a-4167-b6db-67ef3e94acbc">


## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

