### PR TITLE
[BUG] `Home Page` Elements are no more Concinding over other 

### DIFF
--- a/faq.css
+++ b/faq.css
@@ -5,10 +5,10 @@ html {
 
 /* FAQ Container styling */
 .faq-container {
-  margin-top: 15px ;
+  margin-top: 25px ;
+  margin-bottom: 25px;
   padding: 80px;
   max-width: 800px;
-  margin: 0 auto;
   background-color: #f7f7f7;
   border-radius: 10px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);

--- a/faq.css
+++ b/faq.css
@@ -5,7 +5,8 @@ html {
 
 /* FAQ Container styling */
 .faq-container {
-  padding: 50px;
+  margin-top: 15px ;
+  padding: 80px;
   max-width: 800px;
   margin: 0 auto;
   background-color: #f7f7f7;


### PR DESCRIPTION
## What does this PR do?
(already much solved)

- added proper css features like margin-top  & margin-bottom
- ensures no further  overlapping with any section

Fixes #769 


- Then
![image](https://github.com/user-attachments/assets/3c708da1-a705-40fe-8261-e76b27f06735)
- Now

![image](https://github.com/user-attachments/assets/027c351f-9e32-4d78-ba69-2b456613d9fb)


## Type of change



- Bug fix (non-breaking change which fixes an issue)


@ankit071105 
## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.