### PR TITLE
Enhanced ScrollTop Button Functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -1516,6 +1516,15 @@ animateCircles();
     <!-- AOS Library & Initialization Script -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
     <script>
+        const scrollTopBtn = document.getElementById("topBtn");
+        scrollTopBtn.style.setProperty('visibility', 'hidden', 'important');
+        window.addEventListener('scroll', function() {
+            if (window.scrollY > 100) {
+                scrollTopBtn.style.setProperty('visibility', 'visible', 'important');
+            } else {
+                scrollTopBtn.style.setProperty('visibility', 'hidden', 'important');
+            }
+        });
         AOS.init();
     </script>
 


### PR DESCRIPTION
## Enhanced ScrollTop Button Functionality

Fix #832 

- Sets the initial visibility of the scrollTop button to hidden, improving the overall user interface by reducing clutter.
- The button becomes visible only after scrolling down more than 100 pixels, enhancing usability and encouraging seamless navigation back to the top.

@ankit071105
Pls assign me, give me labels like gssoc-extd, hacktoberfest-accepted, and level.