### PR TITLE
Hiding Cursor on Mobile View

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1195,6 +1195,12 @@ button:hover {
   }
 
 
+@media (max-width: 768px) {
+  .circle {
+      display: none;
+  }
+}
+
 
 
 


### PR DESCRIPTION
### Hiding Cursor on Mobile View

Fix #903 

This PR implements a solution to hide the `circle` on screens 768 pixels wide or smaller. The visibility is controlled using CSS media queries to enhance the mobile user experience.

@ankit071105 
Pls give me labels like gssoc-extd, level and assign me this issue.