### PR TITLE
change the heading color to white when switched to dark mode 

### DIFF
--- a/contributor.css
+++ b/contributor.css
@@ -530,8 +530,14 @@ body.dark-mode .contributor-stats-grid,
 body.dark-mode .contributor-contributors-grid {
     color: #000000; /* Text color for content in dark mode */
 }
-
+body.dark-mode .contributor-stats h2{
+  color:white;
+}
+body.dark-mode .contributor-contributors h2{
+  color:white;
+}
 /* Optional: Background color for dark mode */
 body.dark-mode {
     background-color: #121212; /* Example dark background */
 }
+


### PR DESCRIPTION
## What does this PR do?

changes the heading color to white when switched to dark mode  in contributors section.

Fixes #914

SCREENSHOTS 👍: 

![image](https://github.com/user-attachments/assets/d4ef559c-f8b4-494a-b847-1d55b999b10c)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)



## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.