### PR TITLE
🛠️FIX : Contact us page name and email field validation added

### DIFF
--- a/contactus.html
+++ b/contactus.html
@@ -387,11 +387,11 @@
             <form id="contactForm">
                 <div class="form-cont">
                     <label for="name">Your Name:</label>
-                    <input type="text" id="name" placeholder="Enter your full name" required>
+                    <input type="text" id="name" placeholder="Enter your full name" required pattern="[A-Za-z\s]+" title="Please enter a valid name (Without numbers and special characters)">
                   </div>
                   <div class="form-cont">
                     <label for="email">Email Address:</label>
-                    <input type="text" id="email" placeholder="Enter your email" required>
+                    <input type="email" id="email" placeholder="Enter your email" required>
                   </div>
                   <div class="form-cont">
                     <label for="name">Subject:</label>


### PR DESCRIPTION
## What does this PR do?

On the Contact Us page name and email field validation were added. now name field only accepts alphabets,and the email only accepts a valid email address/

Fixes #999 



## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Screenshots 

https://github.com/user-attachments/assets/13a584ee-7b56-44f0-9188-87ecd8c1b9e9


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent-sized PR without self-review might be rejected.